### PR TITLE
Don't allow the player to suicide by doing a 180

### DIFF
--- a/snake.rs
+++ b/snake.rs
@@ -69,10 +69,16 @@ impl Snake {
 
     fn key_press(&mut self, k: Key) {
         use piston::input::keyboard::Key::*;
+        // Don't allow a player to kill themselves by doing a 180
         match k {
-            Right | Down | Left | Up => self.last_pressed = k,
-            _ => {},
+            Right if self.last_pressed != Left => {},
+            Left if self.last_pressed != Right => {},
+            Up if self.last_pressed != Down => {},
+            Down if self.last_pressed != Up => {}
+            _ => return
         }
+
+        self.last_pressed = k;
     }
 
     fn mv(g: &mut Game, dtxy: (i8, i8)) {


### PR DESCRIPTION
The controls are still a bit wonky, e.g. if you want to do a 180 by doing a quick two button combination it usually doesn't work due to the timing and last_pressed only storing a single move. I guess you could class this as skillful requirement though :P 

But anyway, without this fix, then quick turns are usually fatal, e.g. moving `Right` you hit a quick `Down` then `Left`, it saves `Left` as `last_pressed` and you :skull: _die_ :skull:.
