### PR TITLE
Fixed mut warning by changing the macro to not require a mutable vector.

### DIFF
--- a/snake.rs
+++ b/snake.rs
@@ -219,11 +219,11 @@ impl Food {
 macro_rules! walls {
     ( $( $x:expr, $y:expr ),* ) => {
         {
-            let mut v = Vec::new();
+            vec![
             $(
-                v.push(Point{x:$x, y:$y});
+                Point{x:$x, y:$y},
             )*
-            v
+            ]
         }
     };
 }


### PR DESCRIPTION
I was getting a warning when building (both on 1.0 and on nightly) complaining about the "unnecessary" mutable vector in the macro.

This fix makes it immutable, which solves the problem.
